### PR TITLE
Fixed bug "Convert hex string to decimal number #58" and made String init() 23 times faster with 60K digits.

### DIFF
--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -306,49 +306,6 @@ public struct BInt:
 	{
 		self.init(limbs: [Limb(n)])
 	}
-    
-//    private static let maxPowerOf10 = 19
-//    private static var multipliers10:[Digit] = {
-//        var multipliers = [Digit]()
-//        var x = Digit(1)
-//        for _ in 1...maxPowerOf10 {
-//            x *= 10
-//            multipliers.append(x)
-//        }
-//        return multipliers
-//    }()
-
-	/// Create an instance initialized to a string value.
-//	public init?(_ str: String)
-//	{
-//		var (str, sign, /*base,*/ limbs) = (str, false, /*[Limb(1)],*/ [Limb(0)])
-//
-//		limbs.reserveCapacity(Int(Double(str.count) / log10(pow(2.0, 64.0))))
-//
-//		if str.hasPrefix("-")
-//		{
-//			str.removeFirst()
-//			sign = str != "0"
-//		}
-//
-//        var chunk=""; chunk.reserveCapacity(BInt.maxPowerOf10)
-//        while !str.isEmpty {
-//            chunk=""
-//            for _ in 1...BInt.maxPowerOf10 where !str.isEmpty {
-//                chunk.append(str.removeFirst())
-//            }
-//            if let num = Limb(chunk)
-//            {
-//                limbs = limbs.multiplyingBy([BInt.multipliers10[chunk.count-1]])
-//                limbs.addProductOf(multiplier: [1], multiplicand: num)
-//            }
-//            else
-//            {
-//                return nil
-//            }
-//        }
-//        self.init(sign: sign, limbs: limbs)
-//    }
 
 	/// Create an instance initialized to a string with the value of mathematical numerical
 	/// system of the specified radix (base). So, for example, to get the value of hexadecimal
@@ -436,30 +393,6 @@ public struct BInt:
 		}
 		self.init(sign: sign, limbs: limbs)
 	}
-
-	/// Create an instance initialized to a string with the value of mathematical numerical
-	/// system of the specified radix (base). You have to specify the base as a prefix, so for
-	/// example, "0b100101010101110" is a vaild input for a binary number. Currently,
-	/// hexadecimal (0x), octal (0o) and binary (0b) are supported.
-//	public init?(prefixedNumber number: String)
-//	{
-//		if number.hasPrefix("0x")
-//		{
-//			self.init(String(number.dropFirst(2)), radix: 16)
-//		}
-//		if number.hasPrefix("0o")
-//		{
-//			self.init(String(number.dropFirst(2)), radix: 8)
-//		}
-//		if number.hasPrefix("0b")
-//		{
-//			self.init(String(number.dropFirst(2)), radix: 2)
-//		}
-//		else
-//		{
-//			return nil
-//		}
-//	}
 
 	//	Requierd by protocol ExpressibleByFloatLiteral.
 	public init(floatLiteral value: Double)
@@ -1122,29 +1055,31 @@ public struct BInt:
 
 fileprivate extension String
 {
+	// FIXME: The *split* causes a massive overhead due to *self* calls. Please remove.
+	// Alternatives have been implemented.
 	// Splits the string into equally sized parts (except for the last one).
-	func split(_ count: Int) -> [String] {
-        var x = self
-        var splits = [String]()
-        var s = ""; s.reserveCapacity(count)
-        while !x.isEmpty {
-            s = ""
-            for _ in 1...count where !x.isEmpty {
-                s.append(x.removeFirst())
-            }
-            splits.append(s)
-        }
+//	func split(_ count: Int) -> [String] {
+//        var x = self
+//        var splits = [String]()
+//        var s = ""; s.reserveCapacity(count)
+//        while !x.isEmpty {
+//            s = ""
+//            for _ in 1...count where !x.isEmpty {
+//                s.append(x.removeFirst())
+//            }
+//            splits.append(s)
+//        }
 //        while x.count > 0 {
 //            splits.append(String(x.prefix(count)))
 //            x = String(x.dropFirst(count))
 //        }
-        return splits
+ //       return splits
 //		return stride(from: 0, to: self.count, by: count).map { i -> String in
 //			let start = index(startIndex, offsetBy: i)
 //			let end = index(start, offsetBy: count, limitedBy: endIndex) ?? endIndex
 //			return String(self[start..<end])
 //		}
-	}
+//	}
 }
 
 fileprivate let DigitBase:     Digit = 1_000_000_000_000_000_000

--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -2015,10 +2015,10 @@ fileprivate extension Array where Element == Limb
 //
 //
 //
-public class BIntMath
+internal class BIntMath
 {
 	/// Returns true iff (2 ** exp) - 1 is a mersenne prime.
-	static public func isMersenne(_ exp: Int) -> Bool
+	static func isMersenne(_ exp: Int) -> Bool
 	{
 		var mersenne = Limbs(repeating: Limb.max, count: exp >> 6)
 
@@ -2103,12 +2103,12 @@ public class BIntMath
 		return a.divMod(steinGcd(a, b)).quotient.multiplyingBy(b)
 	}
 
-	static public func lcm(_ a:BInt, _ b:BInt) -> BInt
+	static func lcm(_ a:BInt, _ b:BInt) -> BInt
 	{
 		return BInt(limbs: lcmPositive(a.limbs, b.limbs))
 	}
 
-	static public func fib(_ n:Int) -> BInt
+	static func fib(_ n:Int) -> BInt
 	{
 		var a: Limbs = [0], b: Limbs = [1], t: Limbs
 
@@ -2123,14 +2123,14 @@ public class BIntMath
 	}
 
 	///	Order matters, repetition not allowed.
-	static public func permutations(_ n: Int, _ k: Int) -> BInt
+	static func permutations(_ n: Int, _ k: Int) -> BInt
 	{
 		// n! / (n-k)!
 		return BInt(n).factorial() / BInt(n - k).factorial()
 	}
 
 	///	Order matters, repetition allowed.
-	static public func permutationsWithRepitition(_ n: Int, _ k: Int) -> BInt
+	static func permutationsWithRepitition(_ n: Int, _ k: Int) -> BInt
 	{
 		// n ** k
 		return BInt(n) ** k

--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -1075,10 +1075,18 @@ fileprivate extension String
 	func split(_ count: Int) -> [String] {
         var x = self
         var splits = [String]()
-        while x.count > 0 {
-            splits.append(String(x.prefix(count)))
-            x = String(x.dropFirst(count))
+        while x.count > count {
+            var s = ""; s.reserveCapacity(count)
+            for _ in 1...count {
+                s.append(x.removeFirst())
+            }
+            splits.append(s)
         }
+        if x.count > 0 { splits.append(x) }
+//        while x.count > 0 {
+//            splits.append(String(x.prefix(count)))
+//            x = String(x.dropFirst(count))
+//        }
         return splits
 //		return stride(from: 0, to: self.count, by: count).map { i -> String in
 //			let start = index(startIndex, offsetBy: i)

--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -2015,10 +2015,10 @@ fileprivate extension Array where Element == Limb
 //
 //
 //
-internal class BIntMath
+public class BIntMath
 {
 	/// Returns true iff (2 ** exp) - 1 is a mersenne prime.
-	static func isMersenne(_ exp: Int) -> Bool
+	static public func isMersenne(_ exp: Int) -> Bool
 	{
 		var mersenne = Limbs(repeating: Limb.max, count: exp >> 6)
 
@@ -2103,12 +2103,12 @@ internal class BIntMath
 		return a.divMod(steinGcd(a, b)).quotient.multiplyingBy(b)
 	}
 
-	static func lcm(_ a:BInt, _ b:BInt) -> BInt
+	static public func lcm(_ a:BInt, _ b:BInt) -> BInt
 	{
 		return BInt(limbs: lcmPositive(a.limbs, b.limbs))
 	}
 
-	static func fib(_ n:Int) -> BInt
+	static public func fib(_ n:Int) -> BInt
 	{
 		var a: Limbs = [0], b: Limbs = [1], t: Limbs
 
@@ -2123,14 +2123,14 @@ internal class BIntMath
 	}
 
 	///	Order matters, repetition not allowed.
-	static func permutations(_ n: Int, _ k: Int) -> BInt
+	static public func permutations(_ n: Int, _ k: Int) -> BInt
 	{
 		// n! / (n-k)!
 		return BInt(n).factorial() / BInt(n - k).factorial()
 	}
 
 	///	Order matters, repetition allowed.
-	static func permutationsWithRepitition(_ n: Int, _ k: Int) -> BInt
+	static public func permutationsWithRepitition(_ n: Int, _ k: Int) -> BInt
 	{
 		// n ** k
 		return BInt(n) ** k
@@ -2151,7 +2151,7 @@ internal class BIntMath
 		return BInt(n).factorial() / (BInt(k).factorial() * BInt(n - k).factorial())
 	}
 
-	static func randomBInt(bits n: Int) -> BInt
+	static public func randomBInt(bits n: Int) -> BInt
 	{
 		let limbs = n >> 6
 		let singleBits = n % 64

--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -330,22 +330,25 @@ public struct BInt:
 			str.removeFirst()
 			sign = str != "0"
 		}
-
-        for chunk in str.split(BInt.maxPowerOf10)
-		{
-			if let num = Limb(chunk)
-			{
+        
+        var chunk=""; chunk.reserveCapacity(BInt.maxPowerOf10)
+        while !str.isEmpty {
+            chunk=""
+            for _ in 1...BInt.maxPowerOf10 where !str.isEmpty {
+                chunk.append(str.removeFirst())
+            }
+            if let num = Limb(chunk)
+            {
                 limbs = limbs.multiplyingBy([BInt.multipliers10[chunk.count-1]])
                 limbs.addProductOf(multiplier: [1], multiplicand: num)
-			}
-			else
-			{
-				return nil
-			}
-		}
-
-		self.init(sign: sign, limbs: limbs)
-	}
+            }
+            else
+            {
+                return nil
+            }
+        }
+        self.init(sign: sign, limbs: limbs)
+    }
 
 	/// Create an instance initialized to a string with the value of mathematical numerical
 	/// system of the specified radix (base). So for example, to get the value of hexadecimal
@@ -1075,14 +1078,14 @@ fileprivate extension String
 	func split(_ count: Int) -> [String] {
         var x = self
         var splits = [String]()
-        while x.count > count {
-            var s = ""; s.reserveCapacity(count)
-            for _ in 1...count {
+        var s = ""; s.reserveCapacity(count)
+        while !x.isEmpty {
+            s = ""
+            for _ in 1...count where !x.isEmpty {
                 s.append(x.removeFirst())
             }
             splits.append(s)
         }
-        if x.count > 0 { splits.append(x) }
 //        while x.count > 0 {
 //            splits.append(String(x.prefix(count)))
 //            x = String(x.dropFirst(count))

--- a/Tests/BIntTests.swift
+++ b/Tests/BIntTests.swift
@@ -20,6 +20,12 @@ class BIntTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+    
+//    func testSizeString()
+//    {
+//        let x = BInt(1234567890123456789)
+//        print(x.sizeDescription)
+//    }
 
 	func testRadixInitializerAndGetter()
 	{

--- a/Tools/MG Matrix.swift
+++ b/Tools/MG Matrix.swift
@@ -17,6 +17,7 @@ protocol NumericType:
 
 extension Double: NumericType
 {
+    // FIXME: Compiler warns about function call causing infinite recursion - MG
 	init<T: NumericType>(_ n: T) {
 		self.init(n)
 	}
@@ -468,6 +469,7 @@ func -=<T>(A: inout Matrix<T>, B: Matrix<T>)
 
 func -<T>(A: Matrix<T>, B: Matrix<T>) -> Matrix<T>
 {
+    // FIXME: Compiler warns about function call causing infinite recursion - MG 
 	return A - B
 }
 


### PR DESCRIPTION
I fixed a few things including bug #58 with my merging of the different String init() functions.  As a bonus, this init() is now about 23 times faster than it was and much easier to use.  Overall, I was impressed by the speed of the various features with this one exception  — so I had to fix it. 😉

I also fixed your magnitude function which now works correctly (at least how Apple intended).  

BTW, I recommend removing the String.split since it was one major element responsible for slowing down the init().  

I also noticed a bug with the random number creation where the bit sizes would be incorrect sometimes.  This led me down a rabbit-hole in checking the true definition of the bitSize which is not defined how one would think.  It is supposed to specify the actual size of the type on the underlying hardware — not the number of bits in a number as most people think.  You can verify how Apple views this by performing the simple test: Int32(1).bitWidth = 32, not 1.  Perhaps we need to define a new attribute like `actualBitWidth`.

I added some tags so that the Swift Package versions work correctly.  The SPM does not like 'v's in front of the version numbers.

Overall, I really like the work you've done and may contribute some more bits and pieces.

