### PR TITLE
Fix decimals expressed in scientific notation bug.

### DIFF
--- a/Sources/Swift-Big-Number-Core.swift
+++ b/Sources/Swift-Big-Number-Core.swift
@@ -2326,7 +2326,7 @@ public struct BDouble:
                         if beforeExp.starts(with: "+") || beforeExp.starts(with: "-") {
                             safeAfterExp = safeAfterExp - beforeExp.count + 2
                         } else {
-                            safeAfterExp = safeAfterExp - beforeExp.count + 1
+                            safeAfterExp = safeAfterExp + (beforeExp.count - 1)
                         }
 						// if safeAfterExp is negative this results in a crash
 						// more testing and test cases needed
@@ -2346,7 +2346,7 @@ public struct BDouble:
                         if beforeExp.starts(with: "+") || beforeExp.starts(with: "-") {
                             safeAfterExp = safeAfterExp - beforeExp.count + 2
                         } else {
-                            safeAfterExp = safeAfterExp - beforeExp.count + 1
+                            safeAfterExp = safeAfterExp - (beforeExp.count - 1)
                         }
 						let num = beforeExp + String([Character](repeating: "0", count: abs(safeAfterExp)))
 						self.init(num, over: "1")

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -321,6 +321,18 @@ class BDoubleTests : XCTestCase {
 		XCTAssertEqual(bigD?.decimalDescription, "0.000000000300000")
 		bigD?.precision = 5
 		XCTAssertEqual(bigD?.decimalDescription, "0.00000")
+		
+		bigD = BDouble("0.00000012")
+		bigD?.precision = 9
+		XCTAssertEqual(bigD?.decimalDescription, "0.000000120")
+		
+		bigD = BDouble("1.2e-7")
+		bigD?.precision = 9
+		XCTAssertEqual(bigD?.decimalDescription, "0.000000120")
+		
+		bigD = BDouble("5.7156430570677954e-05")
+		bigD?.precision = 21
+		XCTAssertEqual(bigD?.decimalDescription, "0.000057156430570677954")
 	}
 	
 	func testNearlyEqual() {


### PR DESCRIPTION
If a number is "1.2e-7", after convert to BDouble, its decimalDescription should be "0.00000012".

Please check and merge the pull request.
